### PR TITLE
Change protocol git:// -> https://

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -21,7 +21,7 @@ MRuby::Gem::Specification.new('mruby-vedis') do |spec|
   if ! File.exists? vedis_dir
     Dir.chdir(build_dir) do
       e = {}
-      run_command e, 'git clone git://github.com/symisc/vedis.git'
+      run_command e, 'git clone https://github.com/symisc/vedis.git'
     end
   end
 


### PR DESCRIPTION
# ref

- [Change the protocol used to download hiredis from git to https by windyakin · Pull Request #105 · matsumotory/mruby-redis](https://github.com/matsumotory/mruby-redis/pull/105)

# error log

```
(……snip……)
build: [exec] git clone git://github.com/symisc/vedis.git
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Cloning into 'vedis'...
rake aborted!
git clone git://github.com/symisc/vedis.git failed
(……snip……)
```